### PR TITLE
Prevent react warning for value=null on hint input

### DIFF
--- a/src/components/typeahead.jsx
+++ b/src/components/typeahead.jsx
@@ -171,7 +171,7 @@ module.exports = React.createClass({
                         WebkitTextFillColor: 'silver',
                         position: 'absolute'
                     }}
-                    value={state.isHintVisible ? props.handleHint(inputValue, props.options) : null}
+                    value={state.isHintVisible ? props.handleHint(inputValue, props.options) : undefined}
                 />
                 <Input
                     ref='input'


### PR DESCRIPTION
With React 15.0.1 when there is no hint and the hint input's value is set to null, react warns:
```
Warning: `value` prop on `input` should not be null. Consider using the empty string to clear the component or `undefined` for uncontrolled components.
```
Changing null to undefine resolves this.